### PR TITLE
Add type hints to remove reflection calls

### DIFF
--- a/src/baizen/core.clj
+++ b/src/baizen/core.clj
@@ -15,7 +15,7 @@
 
 (defmethod parse
   java.io.Reader
-  [reader]
+  [^java.io.Reader reader]
   (with-open [rdr reader]
     (let [lines (csv/read-csv rdr)
           preprocessed (continuations/preprocess lines)

--- a/src/baizen/formats.clj
+++ b/src/baizen/formats.clj
@@ -20,7 +20,7 @@
 
 (defprotocol BaiFormat
   "A clojure protocol for describing a BAI record format."
-  (fields [f])
+  (^java.util.List fields [f])
   (prepare [f line]))
 
 (defn index-of [this key]


### PR DESCRIPTION
I noticed that baizen had a couple of reflection calls, so I fixed 'em with these type hints.
